### PR TITLE
improved TextAnalyzer speed

### DIFF
--- a/src/WordCounter.php
+++ b/src/WordCounter.php
@@ -12,11 +12,11 @@ final class WordCounter {
 
     private array $supportedCharacterMap = [];
 
-    public function process(string $text, bool $exportWords = false, string $encoding = 'UTF-8'): WordCounterResult {
+    public function process(string $text, bool $exportWords = false): WordCounterResult {
         $wordCount = 0;
         $wordList = [];
 
-        $textAnalyzer = new TextAnalyzer($text, $encoding);
+        $textAnalyzer = new TextAnalyzer($text);
         $textAnalyzer->analyze(
             function (string $currentCharacter, ?string $previousCharacter): bool {
                 return $this->onCharacterMatch($currentCharacter, $previousCharacter);

--- a/tests/Unit/TextAnalyzerTest.php
+++ b/tests/Unit/TextAnalyzerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordCounter\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use WordCounter\TextAnalyzer;
+
+class TextAnalyzerTest extends TestCase {
+
+    public function testCanAnalyzeText(): void {
+        $expected = 'aαаاअ一あㅏ龍b藤บשcصЩ🤯🦄麻漢락憂';
+        $processed = '';
+
+        $textAnalyzer = new TextAnalyzer($expected);
+        $textAnalyzer->analyze(
+            static function(): bool {
+                return true;
+            },
+            static function(string $word) use (&$processed): void {
+                $processed = $word;
+            }
+        );
+
+        static::assertEquals($processed, $processed);
+    }
+
+}

--- a/tests/Unit/WordCounter/ArabicScriptTest.php
+++ b/tests/Unit/WordCounter/ArabicScriptTest.php
@@ -22,8 +22,8 @@ class ArabicScriptTest extends TestCase {
     public function testWordCounter(string $text, int $expectedCount, array $expectedWords): void {
         $wordCounterResult = $this->wordCounter->process($text, true);
 
-        $this->assertEquals($expectedCount, $wordCounterResult->getCount());
         $this->assertEquals($expectedWords, $wordCounterResult->getWords());
+        $this->assertEquals($expectedCount, $wordCounterResult->getCount());
     }
 
     public static function wordCounterData(): array {

--- a/tests/Unit/WordCounter/LatinScriptTest.php
+++ b/tests/Unit/WordCounter/LatinScriptTest.php
@@ -22,8 +22,8 @@ class LatinScriptTest extends TestCase {
     public function testWordCounter(string $text, int $expectedCount, array $expectedWords): void {
         $wordCounterResult = $this->wordCounter->process($text, true);
 
-        $this->assertEquals($expectedCount, $wordCounterResult->getCount());
         $this->assertEquals($expectedWords, $wordCounterResult->getWords());
+        $this->assertEquals($expectedCount, $wordCounterResult->getCount());
     }
 
     public static function wordCounterData(): array {


### PR DESCRIPTION
What's done:
 - speed improved by 6,57s
 - implemented unit test for TextAnalyzer

Benchmark before improvement:
WordCounterBench::benchCounter() - 1,635,216b - 6,881,077.000μs
WordCounterBench::benchCounterWithWordsExport() - 2,112,968b - 6,858,021.000μs

Benchmark after improvement:
WordCounterBench::benchCounter() - 1,740,544b - 312,466.000μs
WordCounterBench::benchCounterWithWordsExport() - 2,115,576b - 371,145.000μs